### PR TITLE
fix ./dist subpath to ./dist/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.1",
   "description": "This esbuild plugin uses Velcro to build projects without having to npm install dependencies",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "browser": {},
   "exports": {
     ".": {
       "require": "./dist/index.cjs.js",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "default": "./dist/index.cjs.js"
     },
     "./dist/": "./dist/*",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       },
       "default": "./dist/index.cjs.js"
     },
-    "./dist/": "./dist/"
+    "./dist/": "./dist/*"
   },
   "files": [
     "dist/**/!(tsconfig.tsbuildinfo)"


### PR DESCRIPTION
I got this error,

(node:18010) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./dist/" in the "exports" field module resolution of the package at /workspaces/bundle/node_modules/esbuild-plugin-velcro/package.json imported from /workspaces/bundle/gulpfile.js.
Update this package.json to use a subpath pattern like "./dist/*".

So I thought, I'd add a quick fix
